### PR TITLE
Propostion for Lua 5.3 fix

### DIFF
--- a/lightning_mdb.lua
+++ b/lightning_mdb.lua
@@ -6,7 +6,7 @@ require "conf"
 
 local disable_cache = false
 
-local lightningmdb = _VERSION=="Lua 5.2" and lightningmdb_lib or lightningmdb
+local lightningmdb = _VERSION >= "Lua 5.2" and lightningmdb_lib or lightningmdb
 
 local NUM_PAGES = 256000
 local MAX_SLOTS_IN_SPARSE_SEQ = 10

--- a/purepack.lua
+++ b/purepack.lua
@@ -1,6 +1,9 @@
 local bit32_found,bit32 = pcall(require,"bit32")
 local bit_found,bit = pcall(require,"bit")
-local lmdb_found,lightningmdb_lib = pcall(require,"lightningmdb") -- contains LHF's lpack (introduces string.pack and string.unpack)
+
+-- For Lua versions older than 5.3, lightningmdb contains LHF's lpack
+-- which introduces string.pack and string.unpack.
+local lmdb_found,lightningmdb_lib = pcall(require,"lightningmdb")
 
 local nop = function() end
 
@@ -17,7 +20,12 @@ local function set_pack_lib(lib_)
   local function helper()
     local bits_lib = (bit32_found and bit32) or (bit_found and bit)
 
+    if lib_=="lpack" and _VERSION >= 'Lua 5.3' then
+      lib_ = "native"
+    end
+
     if lib_=="lpack" then
+
       if not string.pack or not string.unpack then
         return nil,"purepack - lpack not found"
       end
@@ -45,6 +53,34 @@ local function set_pack_lib(lib_)
       end
 
       return true
+    end
+
+    if lib_=="native" then
+      if _VERSION < "Lua 5.3" then
+        return nil,"purepack - cannot use native packing, Lua version too low"
+      end
+
+      M.to_binary = function(int_)
+        return (string.pack(">I",int_))
+      end
+
+      M.to_binary3 = function(a_,b_,c_)
+        return (string.pack(">III",a_,b_,c_))
+      end
+
+      M.from_binary = function(str_,s)
+        return (string.unpack(">I",str_,s))
+      end
+
+      M.from_binary3 = function(str_,s)
+        local a,b,c = string.unpack(">III",str_,s)
+        return a,b,c
+      end
+
+      M.concat_three_strings = function(a_,b_,c_)
+        return table.concat({a_ or "",b_ or "",c_ or ""})
+      end
+
     end
 
     if lib_=="bits" then


### PR DESCRIPTION
Mostly implements a "native" packer that uses `string.pack` and `string.unpack` from the standard library instead of lpack.

I believe this fixes at least part of the issues raised in [this comment](https://github.com/shmul/lightningmdb/pull/7#issuecomment-131556741) on the lightningmdb project. On my machine, it makes the purepack tests pass. Some other tests still fail, for instance the trie tests fail because no packing library is set so they use NOPs:

```
  1) Error! (test_trie.test_pack):
./purepack.lua:230: ./purepack.lua:192: wrong number of arguments to 'insert'
    [C]: in function 'push'
    ./purepack.lua:230: in function 'helper'
    ./purepack.lua:243: in function 'pack_helper'
    ./purepack.lua:248: in function <./purepack.lua:246>
    tests/test_trie.lua:174: in function <tests/test_trie.lua:166>
    [C]: in function 'xpcall'
    stdin:11: in main chunk
    [C]: ?
```

and the "mule" test fails for a reason I do not know:

```
  1) Failure (test_mule.test_create):
tests/test_mule.lua:36: expected 11392 but was 2111
```

DCO 1.1 Signed-off-by: Pierre Chapuis catwell@archlinux.us
